### PR TITLE
locking pnpm version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,13 +53,13 @@ node {
 }
 
 task pnpmInstall(type: NpxTask) {
-    command = "pnpm"
+    command = "pnpm@7"
     args = ["install"]
 }
 
 task buildFrontend(type: NpxTask) {
-    command = 'pnpm'
-    args = ['build']
+    command = "pnpm@7"
+    args = ["build"]
 }
 
 build {


### PR DESCRIPTION
锁定 pnpm 版本为 7，解决 ci 报错问题。

/kind bug

```release-note
None
```