### PR TITLE
feat: support iframe and lazy-load display of media resources.

### DIFF
--- a/console/src/components/MomentPreview.vue
+++ b/console/src/components/MomentPreview.vue
@@ -38,6 +38,28 @@ const vHighlight = {
   },
 };
 
+const vLazy = {
+  mounted: (el: HTMLElement) => {
+    // iframe
+    const iframes = el.querySelectorAll<any>("iframe");
+    iframes.forEach((iframe: any) => {
+      iframe.loading = "lazy";
+      iframe.importance = "low";
+    });
+    // 图片
+    const imgs = el.querySelectorAll<HTMLImageElement>("img,image");
+    imgs.forEach((img: HTMLImageElement) => {
+      img.loading = "lazy";
+    });
+    // 视频，音频
+    const medium = el.querySelectorAll<HTMLMediaElement>("video,audio");
+    medium.forEach((media: HTMLMediaElement) => {
+      media.autoplay = false;
+      media.preload = "metadata";
+    });
+  },
+};
+
 const mediums = ref(props.moment.spec.content.medium || []);
 const detailVisible = ref<boolean>(false);
 const selectedIndex = ref<number>(0);
@@ -151,7 +173,7 @@ const getExtname = (type: string) => {
     <div
       class="moment-preview-html moments-overflow-hidden moments-relative moments-pt-1"
     >
-      <div v-highlight v-html="props.moment.spec.content.html"></div>
+      <div v-highlight v-lazy v-html="props.moment.spec.content.html"></div>
     </div>
     <div
       v-if="

--- a/console/src/components/TextEditor.vue
+++ b/console/src/components/TextEditor.vue
@@ -31,6 +31,7 @@ import {
   ExtensionPlaceholder,
   ExtensionHighlight,
   ExtensionCommands,
+  ExtensionIframe,
   CommandsSuggestion,
   CommentParagraph,
   CommandCodeBlock,
@@ -143,6 +144,7 @@ const editor = useEditor({
     ExtensionCodeBlock.configure({
       lowlight,
     }),
+    ExtensionIframe,
     Extension.create({
       addGlobalAttributes() {
         return [


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

为瞬间编辑器添加 `ExtensionIframe` 扩展，并对展示列表的 iframe、image 等进行懒加载处理。

#### Which issue(s) this PR fixes:

Fixes #6 

#### Special notes for your reviewer:

测试方式：

1. 安装可测试插件 [plugin-moments-1.0.0-SNAPSHOT.jar.zip](https://github.com/halo-sigs/plugin-moments/files/11147099/plugin-moments-1.0.0-SNAPSHOT.jar.zip)
2. 在编辑器复制一个 iframe 资源，查看是否能够正常识别，如下所示：
![image](https://user-images.githubusercontent.com/31335418/229754654-bdaa81b2-bfb3-4c2d-9815-70c100db4d24.png)

#### Does this PR introduce a user-facing change?

```release-note
瞬间编辑器支持 `iframe` ，并优化列表资源过多的情况下，整体会卡顿的问题。
```
