### PR TITLE
refactor: media display layout

### DIFF
--- a/console/src/components/MediaCard.vue
+++ b/console/src/components/MediaCard.vue
@@ -39,7 +39,7 @@ const getExtname = (type: string) => {
 <template>
   <div class="moments-relative moments-overflow-hidden">
     <template v-if="props.media.type == 'PHOTO'">
-      <div class="aspect-w-10 aspect-h-8">
+      <div class="moments-aspect-w-1 moments-aspect-h-1">
         <img
           :src="props.media.url"
           class="moments-object-cover"
@@ -48,7 +48,7 @@ const getExtname = (type: string) => {
       </div>
     </template>
     <template v-else-if="props.media.type == 'VIDEO'">
-      <div class="aspect-w-10 aspect-h-8">
+      <div class="moments-aspect-w-1 moments-aspect-h-1">
         <video
           v-if="canPlayType(props.media.originType)"
           class="moments-object-cover"

--- a/console/src/components/MomentEdit.vue
+++ b/console/src/components/MomentEdit.vue
@@ -305,11 +305,14 @@ function handleKeydown(event: KeyboardEvent) {
       v-if="formState.spec.content.medium?.length"
       class="img-box moments-flex moments-px-3.5 moments-py-2"
     >
-      <ul role="list">
+      <ul
+        class="moments-grid moments-grid-cols-3 moments-gap-1.5 moments-w-full sm:moments-w-1/2"
+        role="list"
+      >
         <li
           v-for="(media, index) in formState.spec.content.medium"
           :key="index"
-          class="moments-rounded-md moments-border moments-overflow-hidden moments-inline-block moments-mr-2 moments-mb-2 moments-w-20"
+          class="moments-rounded-md moments-border moments-overflow-hidden moments-inline-block"
         >
           <MediaCard :media="media" @remove="removeMedium"></MediaCard>
         </li>

--- a/console/src/components/MomentPreview.vue
+++ b/console/src/components/MomentPreview.vue
@@ -210,13 +210,19 @@ const getExtname = (type: string) => {
       "
       class="img-box moments-flex moments-pt-2"
     >
-      <ul role="list">
+      <ul
+        class="moments-grid moments-grid-cols-3 moments-gap-1.5 moments-w-full sm:moments-w-1/2"
+        role="list"
+      >
         <li
           v-for="(media, index) in props.moment.spec.content.medium"
           :key="index"
-          class="moments-rounded-md moments-border moments-overflow-hidden moments-inline-block moments-mr-2 moments-mb-2 moments-w-28 moments-cursor-pointer"
+          class="moments-rounded-md moments-border moments-overflow-hidden moments-inline-block moments-cursor-pointer"
         >
-          <div class="aspect-w-10 aspect-h-8" @click="handleClickMedium(index)">
+          <div
+            class="moments-aspect-w-1 moments-aspect-h-1"
+            @click="handleClickMedium(index)"
+          >
             <template v-if="media.type == 'PHOTO'">
               <img
                 :src="media.url"


### PR DESCRIPTION
优化瞬间媒体的排列布局，改为 9 宫格展示。

<img width="887" alt="图片" src="https://github.com/halo-sigs/plugin-moments/assets/21301288/c37411aa-19c4-4b19-9d74-8a9176ede918">

/kind improvement
Fixes #56 

```release-note
优化瞬间媒体的排列布局，改为 9 宫格展示。
```