### PR TITLE
fix: access the list interface without logging in

### DIFF
--- a/console/src/components/MomentEdit.vue
+++ b/console/src/components/MomentEdit.vue
@@ -98,7 +98,7 @@ const queryEditorTags = function () {
 const createMoment = async () => {
   formState.value.spec.releaseTime = new Date().toISOString();
   const { data } = await apiClient.post<Moment>(
-    `/apis/api.plugin.halo.run/v1alpha1/plugins/PluginMoments/moments`,
+    `/apis/console.api.moment.halo.run/v1alpha1/moments`,
     formState.value
   );
   emit("save", data);

--- a/console/src/extensions/tags/TagsExtensionView.vue
+++ b/console/src/extensions/tags/TagsExtensionView.vue
@@ -27,7 +27,7 @@ const { data: tags } = useQuery<string[]>({
   queryKey: ["tags", page, size, keyword],
   queryFn: async () => {
     const { data } = await apiClient.get(
-      "/apis/api.plugin.halo.run/v1alpha1/plugins/PluginMoments/tags",
+      "/apis/console.api.moment.halo.run/v1alpha1/tags",
       {
         params: {
           name: keyword.value,

--- a/console/src/views/MomentsList.vue
+++ b/console/src/views/MomentsList.vue
@@ -88,7 +88,7 @@ const {
     }
 
     const { data } = await apiClient.get(
-      "/apis/api.moment.halo.run/v1alpha1/moments",
+      "/apis/console.api.moment.halo.run/v1alpha1/moments",
       {
         params: {
           page: page.value,

--- a/console/src/views/MomentsList.vue
+++ b/console/src/views/MomentsList.vue
@@ -88,7 +88,7 @@ const {
     }
 
     const { data } = await apiClient.get(
-      "/apis/api.plugin.halo.run/v1alpha1/plugins/PluginMoments/moments",
+      "/apis/api.moment.halo.run/v1alpha1/moments",
       {
         params: {
           page: page.value,

--- a/src/main/java/run/halo/moments/MomentEndpoint.java
+++ b/src/main/java/run/halo/moments/MomentEndpoint.java
@@ -36,9 +36,9 @@ public class MomentEndpoint implements CustomEndpoint {
 
     @Override
     public RouterFunction<ServerResponse> endpoint() {
-        final var tag = "api.plugin.halo.run/v1alpha1/Moment";
+        final var tag = "console.api.moment.halo.run/v1alpha1/Moment";
         return SpringdocRouteBuilder.route()
-            .GET("plugins/PluginMoments/moments", this::listMoment, builder -> {
+            .GET("moments", this::listMoment, builder -> {
                 builder.operationId("ListMoments")
                     .description("List moments.")
                     .tag(tag)
@@ -47,7 +47,7 @@ public class MomentEndpoint implements CustomEndpoint {
                     );
                 QueryParamBuildUtil.buildParametersFromType(builder, MomentQuery.class);
             })
-            .GET("plugins/PluginMoments/tags", this::listTags,
+            .GET("tags", this::listTags,
                 builder -> builder.operationId("ListTags")
                     .description("List all moment tags.")
                     .tag(tag)
@@ -61,7 +61,7 @@ public class MomentEndpoint implements CustomEndpoint {
                     .response(responseBuilder()
                         .implementationArray(String.class)
                     ))
-            .POST("plugins/PluginMoments/moments", this::createMoment,
+            .POST("moments", this::createMoment,
                 builder -> builder.operationId("CreateMoment")
                     .description("Create a Moment.")
                     .tag(tag)
@@ -80,7 +80,7 @@ public class MomentEndpoint implements CustomEndpoint {
 
     @Override
     public GroupVersion groupVersion() {
-        return GroupVersion.parseAPIVersion("api.plugin.halo.run/v1alpha1");
+        return GroupVersion.parseAPIVersion("console.api.moment.halo.run/v1alpha1");
     }
 
     private Mono<ServerResponse> createMoment(ServerRequest serverRequest) {

--- a/src/main/resources/extensions/roleTemplate.yaml
+++ b/src/main/resources/extensions/roleTemplate.yaml
@@ -13,9 +13,8 @@ rules:
   - apiGroups: [ "moment.halo.run"]
     resources: [ "moments" ]
     verbs: [ "get", "list" ]
-  - apiGroups: [ "api.plugin.halo.run"]
-    resources: [ "plugins/moments" ]
-    resourceNames: [ "PluginMoments" ]
+  - apiGroups: [ "console.api.moment.halo.run"]
+    resources: [ "moments", "tags" ]
     verbs: [ "get", "list" ]
 ---
 apiVersion: v1alpha1
@@ -35,7 +34,6 @@ rules:
   - apiGroups: [ "moment.halo.run"]
     resources: [ "moments" ]
     verbs: [ "create", "patch", "update", "delete", "deletecollection" ]
-  - apiGroups: [ "api.plugin.halo.run"]
-    resources: [ "plugins/moments" ]
-    resourceNames: [ "PluginMoments" ]
+  - apiGroups: [ "console.api.moment.halo.run"]
+    resources: [ "moments", "tags" ]
     verbs: [ "create", "patch", "update", "delete", "deletecollection" ]


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

根据 [自定义 API](https://docs.halo.run/developer-guide/plugin/api-reference/server/extension#%E8%87%AA%E5%AE%9A%E4%B9%89-api) 的规则，当 group 为 `api.<group>` 时，此接口默认为为主题端公开的接口。而 moment 在初始定义时，使用了 `api.plugin.halo.run` 作为 group，因此导致其能被公开访问。

本 pr 将 moment 自定义的接口组由 `api.plugin.halo.run` 改为 `console.api.moment.halo.run`，用于解决用户未登录便可访问瞬间列表的问题。

#### How to test it?

未登录状态下，直接访问接口 `/apis/console.api.moment.halo.run/v1alpha1/moments`。 查看是否提示无权限。

#### Which issue(s) this PR fixes:

Fixes #71 

#### Does this PR introduce a user-facing change?
```release-note
解决未认证的用户可以获取瞬间列表的问题
```
