### PR TITLE
fix: unable to stop normally when the startup fails

### DIFF
--- a/src/main/java/run/halo/moments/MomentsPlugin.java
+++ b/src/main/java/run/halo/moments/MomentsPlugin.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.commons.lang3.BooleanUtils;
 import org.springframework.stereotype.Component;
+import run.halo.app.extension.Scheme;
 import run.halo.app.extension.SchemeManager;
 import run.halo.app.extension.index.IndexSpec;
 import run.halo.app.plugin.BasePlugin;
@@ -68,6 +69,6 @@ public class MomentsPlugin extends BasePlugin {
 
     @Override
     public void stop() {
-        schemeManager.unregister(schemeManager.get(Moment.class));
+        schemeManager.unregister(Scheme.buildFromType(Moment.class));
     }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

将 `schemeManager.get(Moment.class)` 改为 `Scheme.buildFromType(Moment.class)`。用于解决启动失败后，无法正常停止资源的问题。

#### How to test it?

测试当插件启动失败后，是否会产生无法找到资源的错误。

#### Which issue(s) this PR fixes:

Fixes #97 

#### Does this PR introduce a user-facing change?
```release-note
解决当插件启动失败时，无法正常停止的问题
```
