### PR TITLE
fix: the picture is cropped when previewing

### DIFF
--- a/console/src/components/PreviewDetailModal.vue
+++ b/console/src/components/PreviewDetailModal.vue
@@ -41,7 +41,7 @@ const onVisibleChange = (visible: boolean) => {
       class="overflow-hidden bg-white moments-flex moments-items-center moments-justify-center moments-h-full"
     >
       <template v-if="props.media.type === 'PHOTO'">
-        <img :src="media?.url" class="moments-w-auto" />
+        <img :src="media?.url" class="moments-w-auto moments-h-full" />
       </template>
       <template v-else-if="props.media.type === 'VIDEO'">
         <video controls muted :src="media?.url">


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

将预览时的图片显示高度设置为 100%。用于解决图片过高时会被裁剪的问题。

#### How to test it?

为瞬间添加一张长图，点击预览，查看长图是否还会被裁剪。

#### Which issue(s) this PR fixes:

Fixes #94 

#### Does this PR introduce a user-facing change?
```release-note
解决图片过高时预览会被裁剪的问题
```
