### PR TITLE
fix: all previously published moments show as under review state after upgrade

### DIFF
--- a/src/main/java/run/halo/moments/MomentMigration.java
+++ b/src/main/java/run/halo/moments/MomentMigration.java
@@ -1,0 +1,49 @@
+package run.halo.moments;
+
+import static run.halo.app.extension.index.query.QueryFactory.and;
+import static run.halo.app.extension.index.query.QueryFactory.isNull;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import run.halo.app.extension.DefaultExtensionMatcher;
+import run.halo.app.extension.ExtensionClient;
+import run.halo.app.extension.controller.Controller;
+import run.halo.app.extension.controller.ControllerBuilder;
+import run.halo.app.extension.controller.Reconciler;
+import run.halo.app.extension.router.selector.FieldSelector;
+
+/**
+ * <p>Migration for 1.16.0, populate approved attribute for all moments before 1.16.0.</p>
+ * <p>Note That: This migration is only for the moments that approved attribute is null.</p>
+ */
+@Component
+@RequiredArgsConstructor
+public class MomentMigration implements Reconciler<Reconciler.Request> {
+
+    private final ExtensionClient client;
+
+    @Override
+    public Result reconcile(Request request) {
+        client.fetch(Moment.class, request.name()).ifPresent(moment -> {
+            moment.getSpec().setApproved(true);
+            moment.getSpec().setApprovedTime(moment.getMetadata().getCreationTimestamp());
+            client.update(moment);
+        });
+        return Result.doNotRetry();
+    }
+
+    @Override
+    public Controller setupWith(ControllerBuilder builder) {
+        final var moment = new Moment();
+        return builder
+            .extension(moment)
+            .onAddMatcher(DefaultExtensionMatcher.builder(client, moment.groupVersionKind())
+                .fieldSelector(FieldSelector.of(
+                    and(isNull("spec.approved"),
+                        isNull("metadata.deletionTimestamp"))
+                ))
+                .build()
+            )
+            .build();
+    }
+}


### PR DESCRIPTION
### What this PR does?
修复 1.6.0 之前发布的瞬间都处于审核中状态的问题

```release-note
修复 1.6.0 之前发布的瞬间都处于审核中状态的问题
```