### PR TITLE
chore: update Node.js and pnpm versions

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -14,5 +14,7 @@ jobs:
     permissions:
       contents: write
     with:
+      node-version: "20"
+      pnpm-version: "9"
       app-id: app-SnwWD
       ui-path: "console"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,4 +12,6 @@ jobs:
   ci:
     uses: halo-sigs/reusable-workflows/.github/workflows/plugin-ci.yaml@v1
     with:
+      node-version: "20"
+      pnpm-version: "9"
       ui-path: "console"


### PR DESCRIPTION
更新 ci/cd 的 node 和 pnpm 版本。

```release-note
None
```