### PR TITLE
Remove highlight.js and related code from console

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -20,7 +20,6 @@
     "dayjs": "^1.11.12",
     "es-toolkit": "^1.39.7",
     "floating-vue": "2.0.0-beta.20",
-    "highlight.js": "^11.10.0",
     "tippy.js": "^6.3.7",
     "vue": "^3.4.37",
     "vue-datepicker-next": "^1.0.3",

--- a/console/pnpm-lock.yaml
+++ b/console/pnpm-lock.yaml
@@ -49,9 +49,6 @@ importers:
       floating-vue:
         specifier: 2.0.0-beta.20
         version: 2.0.0-beta.20(vue@3.4.37(typescript@5.5.4))
-      highlight.js:
-        specifier: ^11.10.0
-        version: 11.10.0
       tippy.js:
         specifier: ^6.3.7
         version: 6.3.7
@@ -1841,10 +1838,6 @@ packages:
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
-
-  highlight.js@11.10.0:
-    resolution: {integrity: sha512-SYVnVFswQER+zu1laSya563s+F8VDGt7o35d4utbamowvUNLLMovFqwCLSocpZTz3MgaSRA1IbqRWZv97dtErQ==}
-    engines: {node: '>=12.0.0'}
 
   highlight.js@11.8.0:
     resolution: {integrity: sha512-MedQhoqVdr0U6SSnWPzfiadUcDHfN/Wzq25AkXiQv9oiOO/sG0S7XkvpFIqWBl9Yq1UYyYOOVORs5UW2XlPyzg==}
@@ -4690,8 +4683,6 @@ snapshots:
       function-bind: 1.1.2
 
   he@1.2.0: {}
-
-  highlight.js@11.10.0: {}
 
   highlight.js@11.8.0: {}
 

--- a/console/pnpm-workspace.yaml
+++ b/console/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 onlyBuiltDependencies:
+  - core-js
   - esbuild
   - vue-demi
 

--- a/console/src/components/MomentPreview.vue
+++ b/console/src/components/MomentPreview.vue
@@ -1,8 +1,6 @@
 <script lang="ts" setup>
 import type { ListedMoment, Moment, MomentMedia } from "@/api/generated";
 import { IconArrowLeft, IconArrowRight, IconMessage } from "@halo-dev/components";
-import hljs from "highlight.js/lib/common";
-import xml from "highlight.js/lib/languages/xml";
 import { computed, inject, ref } from "vue";
 import LucideFileAudio from "~icons/lucide/file-audio";
 import LucideFileVideo from "~icons/lucide/file-video";
@@ -27,16 +25,6 @@ const emit = defineEmits<{
 }>();
 
 const queryClient = useQueryClient();
-
-const vHighlight = {
-  mounted: (el: HTMLElement) => {
-    const blocks = el.querySelectorAll("pre code");
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    blocks.forEach((block: any) => {
-      hljs.highlightBlock(block);
-    });
-  },
-};
 
 const vLazy = {
   mounted: (el: HTMLElement) => {
@@ -161,7 +149,6 @@ function handleOpenCommentList() {
   </PreviewDetailModal>
   <div class=":uno: relative overflow-hidden" @dblclick="handleSwitchEdit">
     <div
-      v-highlight
       v-lazy
       v-tag
       class=":uno: markdown-body moment-preview-html"

--- a/console/src/components/TextEditor.vue
+++ b/console/src/components/TextEditor.vue
@@ -43,7 +43,6 @@ import {
   ExtensionTrailingNode,
   ExtensionUnderline,
   ExtensionVideo,
-  lowlight,
   RichTextEditor,
   type Extensions,
 } from "@halo-dev/richtext-editor";
@@ -119,9 +118,7 @@ const presetExtensions = [
   ExtensionSuperscript,
   ExtensionHighlight,
   ExtensionCommands,
-  ExtensionCodeBlock.configure({
-    lowlight,
-  }),
+  ExtensionCodeBlock,
   ExtensionIframe,
   ExtensionVideo,
   ExtensionAudio,

--- a/console/src/styles/index.scss
+++ b/console/src/styles/index.scss
@@ -180,11 +180,8 @@
         }
 
         pre {
-          padding: 0 !important;
-
           code {
             border: 1px solid #fbf6f6;
-            background: black;
           }
         }
 


### PR DESCRIPTION
修复代码块的显示问题，移除原有的 highlight.js 代码高亮，后续考虑使用 https://github.com/halo-sigs/plugin-shiki 插件高亮渲染代码块。

before: 

<img width="567" height="319" alt="image" src="https://github.com/user-attachments/assets/105f075e-4c7c-4657-bde7-1e51773b5844" />

after:

<img width="569" height="361" alt="image" src="https://github.com/user-attachments/assets/b5d30e58-b250-4527-8908-3227598c5045" />


```release-note
修复瞬间内容中的代码块的显示问题
```