### PR TITLE
feat: support users to view their own published private moments

### DIFF
--- a/src/main/java/run/halo/moments/Moment.java
+++ b/src/main/java/run/halo/moments/Moment.java
@@ -123,4 +123,12 @@ public class Moment extends AbstractExtension {
             return null;
         }
     }
+
+    public boolean isApproved() {
+        return Boolean.TRUE.equals(this.getSpec().getApproved());
+    }
+
+    public boolean isPubliclyVisible() {
+        return MomentVisible.PUBLIC.equals(this.getSpec().getVisible());
+    }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

支持用户在前台查看自己发布的私有瞬间内容。

> 主题可以根据 spec.visible 确定是否为私有内容，以对公开内容与私有内容进行区分。

#### How to test it?

测试主题端访问及使用 `Finder` 时是否可以获取自己发布的私有瞬间内容。以及非登录用户是否隐藏私有瞬间内容。

#### Which issue(s) this PR fixes:

Fixes #161 

#### Does this PR introduce a user-facing change?
```release-note
允许登录用户查看自己发布的私有瞬间
```
