### PR TITLE
feat: add unified parameter list method

### DIFF
--- a/src/main/java/run/halo/moments/finders/MomentFinder.java
+++ b/src/main/java/run/halo/moments/finders/MomentFinder.java
@@ -3,8 +3,10 @@ package run.halo.moments.finders;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import run.halo.app.extension.ListResult;
+import run.halo.moments.finders.impl.MomentFinderImpl.MomentQuery;
 import run.halo.moments.vo.MomentTagVo;
 import run.halo.moments.vo.MomentVo;
+import java.util.Map;
 
 
 /**
@@ -30,6 +32,13 @@ public interface MomentFinder {
      * @return a mono of list result.
      */
     Mono<ListResult<MomentVo>> list(Integer page, Integer size);
+
+    /**
+     * Lists moments by query params.
+     *
+     * @param params query params see {@link MomentQuery}
+     */
+    Mono<ListResult<MomentVo>> list(Map<String, Object> params);
 
     /**
      * List moments by tag.

--- a/src/main/java/run/halo/moments/util/SortUtils.java
+++ b/src/main/java/run/halo/moments/util/SortUtils.java
@@ -1,0 +1,43 @@
+package run.halo.moments.util;
+
+import lombok.experimental.UtilityClass;
+import org.springframework.data.domain.Sort;
+import org.springframework.lang.NonNull;
+import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
+import java.util.List;
+
+@UtilityClass
+public class SortUtils {
+    static final String delimiter = ",";
+
+    /**
+     * <p>Resolve from direction params, e.g. "name,asc" or "name"</p>
+     *
+     * @param directionParams direction params
+     * @return sort object
+     */
+    public static Sort resolve(List<String> directionParams) {
+        if (CollectionUtils.isEmpty(directionParams)) {
+            return Sort.unsorted();
+        }
+        Sort.Order[] orders = new Sort.Order[directionParams.size()];
+        for (int i = 0; i < directionParams.size(); i++) {
+            String[] parts = directionParams.get(i).split(delimiter);
+            if (parts.length == 1) {
+                orders[i] = new Sort.Order(Sort.Direction.ASC, parts[0]);
+            } else {
+                orders[i] = new Sort.Order(toDirection(parts[1]), parts[0]);
+            }
+        }
+        return Sort.by(orders);
+    }
+
+    private static Sort.Direction toDirection(@NonNull String direction) {
+        Assert.notNull(direction, "Direction must not be null");
+        if (direction.contains(" ")) {
+            throw new IllegalArgumentException("Direction must not contain whitespace");
+        }
+        return Sort.Direction.fromString(direction);
+    }
+}


### PR DESCRIPTION
Fixes #175 

```release-note
为 momentFinder 添加一个统一参数的 list 方法并支持传递排序参数
```