### PR TITLE
feat: add unified parameter list method and Public APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,56 @@ halo:
 </ul>
 ```
 
+#### list({...})
+
+```html
+momentFinder.list({
+  page: 1,
+  size: 10,
+  tagName: 'fake-tag',
+  owner: 'fake-owner',
+  sort: {'spec.releaseTime,desc', 'metadata.creationTimestamp,asc'}
+})
+```
+
+统一参数的瞬间列表查询方法，支持分页、标签、创建者、排序等参数，且均为可选参数。
+
+**参数**：
+
+1. page: int - 分页页码，从 1 开始
+2. size: int - 分页条数
+3. tagName:string - 标签
+4. owner:string - 创建者用户名 name
+5. sort:string[] - 排序字段，格式为 字段名,排序方式，排序方式可选值为 asc 或 desc，如 spec.releaseTime,desc，传递时需要使用 {} 形式并用逗号分隔表示数组。
+
+**返回值类型**：[ListResult\<MomentVo>](#listresult-momentvo)
+
+**示例**：
+
+```html
+<th:block th:with="moments = ${momentFinder.list({
+  page: 1,
+  size: 10,
+  tagName: 'fake-tag',
+  owner: 'fake-owner',
+  sort: {'spec.releaseTime,desc', 'metadata.creationTimestamp,asc'}
+})}">
+    <ul>
+        <li th:each="moment : ${moments.items}" th:with="content = ${moment.spec.content}">
+            <div th:if="${not #strings.isEmpty(content.html)}" th:utext="${content.html}"></div>
+            <th:block th:if="${not #lists.isEmpty(content.medium)}" th:each="momentItem : ${content.medium}">
+                <img th:if="${momentItem.type.name == 'PHOTO'}" th:src="${momentItem.url}" />
+                <video th:if="${momentItem.type.name == 'VIDEO'}" th:src="${momentItem.url}"></video>
+                <audio th:if="${momentItem.type.name == 'AUDIO'}" th:src="${momentItem.url}" controls="true"></audio>
+            </th:block>
+        </li>
+    </ul>
+    <div>
+        <span th:text="${moments.page}"></span>
+    </div>
+</th:block>
+```
+
 #### list(page, size)
 
 根据分页参数获取瞬间列表。

--- a/README.md
+++ b/README.md
@@ -88,6 +88,34 @@ halo:
 
 最后重启 Halo 项目即可。
 
+## 公开 API
+
+### 查询瞬间列表
+
+`/apis/api.moment.halo.run/v1alpha1/moments`
+
+**参数**：
+
+1. page: int - 分页页码，从 1 开始
+2. size: int - 分页条数
+3. tag:string - 标签
+4. ownerName:string - 创建者用户名 name
+5. startDate:string - 开始时间 通过时间区间筛选发布时间
+6. endDate:string - 结束时间
+7. sort:string[] - 排序字段，格式为 字段名,排序方式，排序方式可选值为 asc 或 desc，如 spec.releaseTime,desc，
+
+**返回值类型**：[ListResult\<MomentVo>](#listresult-momentvo)
+
+### 查询瞬间详情
+
+`/apis/api.moment.halo.run/v1alpha1/moments/{name}`
+
+**参数**：
+
+1. name:string - 瞬间的唯一标识 name
+
+**返回值类型**：[#MomentVo](#momentvo)
+
 ## 主题适配
 
 目前此插件为主题端提供了 `/moments` 路由，模板为 `moments.html`，也提供了 [Finder API](https://docs.halo.run/developer-guide/theme/finder-apis)，可以将瞬间列表渲染到任何地方。

--- a/src/main/java/run/halo/moments/DefaultQueryMomentPredicateResolver.java
+++ b/src/main/java/run/halo/moments/DefaultQueryMomentPredicateResolver.java
@@ -1,0 +1,65 @@
+package run.halo.moments;
+
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+import run.halo.app.extension.ExtensionUtil;
+import run.halo.app.extension.ListOptions;
+import run.halo.app.extension.router.selector.FieldSelector;
+import run.halo.app.infra.AnonymousUserConst;
+
+import java.security.Principal;
+import java.util.function.Predicate;
+
+import static run.halo.app.extension.index.query.QueryFactory.and;
+import static run.halo.app.extension.index.query.QueryFactory.equal;
+import static run.halo.app.extension.index.query.QueryFactory.isNull;
+import static run.halo.app.extension.index.query.QueryFactory.or;
+
+
+/**
+ * The default implementation of {@link ReactiveQueryMomentPredicateResolver}.
+ *
+ */
+@Component
+public class DefaultQueryMomentPredicateResolver implements ReactiveQueryMomentPredicateResolver {
+
+    @Override
+    public Mono<Predicate<Moment>> getPredicate() {
+        Predicate<Moment> predicate = moment -> moment.isApproved()
+            && !ExtensionUtil.isDeleted(moment);
+        Predicate<Moment> visiblePredicate = Moment::isPubliclyVisible;
+        return currentUserName()
+            .map(username -> predicate.and(
+                visiblePredicate.or(moment -> username.equals(moment.getSpec().getOwner())))
+            )
+            .defaultIfEmpty(predicate.and(visiblePredicate));
+    }
+
+    @Override
+    public Mono<ListOptions> getListOptions() {
+        var listOptions = new ListOptions();
+        var fieldQuery = and(
+            isNull("metadata.deletionTimestamp"),
+            equal("spec.approved", Boolean.TRUE.toString())
+        );
+        var visibleQuery = equal("spec.visible", Moment.MomentVisible.PUBLIC.name());
+        return currentUserName()
+            .map(username -> and(fieldQuery,
+                or(visibleQuery, equal("spec.owner", username)))
+            )
+            .defaultIfEmpty(and(fieldQuery, visibleQuery))
+            .map(query -> {
+                listOptions.setFieldSelector(FieldSelector.of(query));
+                return listOptions;
+            });
+    }
+
+    Mono<String> currentUserName() {
+        return ReactiveSecurityContextHolder.getContext()
+            .map(SecurityContext::getAuthentication)
+            .map(Principal::getName)
+            .filter(name -> !AnonymousUserConst.isAnonymousUser(name));
+    }
+}

--- a/src/main/java/run/halo/moments/MomentPublicQuery.java
+++ b/src/main/java/run/halo/moments/MomentPublicQuery.java
@@ -1,0 +1,134 @@
+package run.halo.moments;
+
+import static org.springdoc.core.fn.builders.parameter.Builder.parameterBuilder;
+import static run.halo.app.extension.index.query.QueryFactory.all;
+import static run.halo.app.extension.index.query.QueryFactory.and;
+import static run.halo.app.extension.index.query.QueryFactory.equal;
+import static run.halo.app.extension.index.query.QueryFactory.greaterThanOrEqual;
+import static run.halo.app.extension.index.query.QueryFactory.lessThanOrEqual;
+import static run.halo.app.extension.router.QueryParamBuildUtil.sortParameter;
+import static run.halo.app.extension.router.selector.SelectorUtil.labelAndFieldSelectorToListOptions;
+
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import org.apache.commons.lang3.StringUtils;
+import org.springdoc.core.fn.builders.operation.Builder;
+import org.springframework.data.domain.Sort;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.server.ServerWebExchange;
+import run.halo.app.extension.ListOptions;
+import run.halo.app.extension.PageRequest;
+import run.halo.app.extension.PageRequestImpl;
+import run.halo.app.extension.router.IListRequest;
+import run.halo.app.extension.router.SortableRequest;
+import run.halo.app.extension.router.selector.FieldSelector;
+
+/**
+ * Query parameters for moment public APIs.
+ *
+ */
+
+public class MomentPublicQuery extends SortableRequest {
+    private final MultiValueMap<String, String> queryParams;
+
+    public MomentPublicQuery(ServerWebExchange exchange) {
+        super(exchange);
+        this.queryParams = exchange.getRequest().getQueryParams();
+    }
+
+    @Schema(description = "Owner name.")
+    public String getOwnerName() {
+        return StringUtils.defaultIfBlank(queryParams.getFirst("ownerName"), null);
+    }
+
+    @Schema(description = "Moment tag.")
+    public String getTag() {
+        return StringUtils.defaultIfBlank(queryParams.getFirst("tag"), null);
+    }
+
+    @Schema
+    public Instant getStartDate() {
+        String startDate = queryParams.getFirst("startDate");
+        return convertInstantOrNull(startDate);
+    }
+
+    @Schema
+    public Instant getEndDate() {
+        String endDate = queryParams.getFirst("endDate");
+        return convertInstantOrNull(endDate);
+    }
+
+    /**
+     * Build {@link ListOptions} from query params.
+     *
+     * @return a list options.
+     */
+    public ListOptions toListOptions() {
+        var listOptions =
+            labelAndFieldSelectorToListOptions(getLabelSelector(), getFieldSelector());
+        var query = all();
+        if (StringUtils.isNotBlank(getOwnerName())) {
+            query = and(query, equal("spec.owner", getOwnerName()));
+        }
+        if (StringUtils.isNotBlank(getTag())) {
+            query = and(query, equal("spec.tags", getTag()));
+        }
+
+        if (getStartDate() != null) {
+            query = and(query, greaterThanOrEqual("spec.releaseTime", getStartDate().toString()));
+        }
+        if (getEndDate() != null) {
+            query = and(query, lessThanOrEqual("spec.releaseTime", getEndDate().toString()));
+        }
+
+        if (listOptions.getFieldSelector() != null) {
+            query = and(query, listOptions.getFieldSelector().query());
+        }
+        listOptions.setFieldSelector(FieldSelector.of(query));
+        return listOptions;
+    }
+
+    public PageRequest toPageRequest() {
+        var sort = getSort();
+        if (sort.isUnsorted()) {
+            sort = Sort.by("spec.releaseTime").descending();
+        }
+        return PageRequestImpl.of(getPage(), getSize(), sort);
+    }
+
+    private Instant convertInstantOrNull(String timeStr) {
+        return StringUtils.isBlank(timeStr) ? null : Instant.parse(timeStr);
+    }
+
+    public static void buildParameters(Builder builder) {
+        IListRequest.buildParameters(builder);
+        builder.parameter(sortParameter())
+            .parameter(parameterBuilder()
+                .in(ParameterIn.QUERY)
+                .name("ownerName")
+                .description("Owner name.")
+                .implementation(String.class)
+                .required(false))
+            .parameter(parameterBuilder()
+                .in(ParameterIn.QUERY)
+                .name("tag")
+                .description("Moment tag.")
+                .implementation(String.class)
+                .required(false))
+            .parameter(parameterBuilder()
+                .in(ParameterIn.QUERY)
+                .name("startDate")
+                .implementation(Instant.class)
+                .description("Moment start date.")
+                .required(false))
+            .parameter(parameterBuilder()
+                .in(ParameterIn.QUERY)
+                .name("endDate")
+                .implementation(Instant.class)
+                .description("Moment end date.")
+                .required(false))
+        ;
+    }
+
+}

--- a/src/main/java/run/halo/moments/MomentQueryEndpoint.java
+++ b/src/main/java/run/halo/moments/MomentQueryEndpoint.java
@@ -1,0 +1,89 @@
+package run.halo.moments;
+
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.webflux.core.fn.SpringdocRouteBuilder;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+import run.halo.app.core.extension.endpoint.CustomEndpoint;
+import run.halo.app.extension.GroupVersion;
+import run.halo.app.extension.ListResult;
+import run.halo.moments.exception.NotFoundException;
+import run.halo.moments.finders.MomentFinder;
+import run.halo.moments.finders.MomentPublicQueryService;
+import run.halo.moments.vo.MomentVo;
+
+import static org.springdoc.core.fn.builders.apiresponse.Builder.responseBuilder;
+import static org.springdoc.core.fn.builders.parameter.Builder.parameterBuilder;
+
+/**
+ * Endpoint for moment query.
+ *
+ */
+@Component
+@RequiredArgsConstructor
+public class MomentQueryEndpoint implements CustomEndpoint {
+
+    private final MomentFinder momentFinder;
+
+    private final MomentPublicQueryService momentPublicQueryService;
+
+    @Override
+    public RouterFunction<ServerResponse> endpoint() {
+        final var tag = "api.moment.halo.run/v1alpha1/Moment";
+        return SpringdocRouteBuilder.route()
+            .GET("moments", this::listMoments,
+                builder -> {
+                    builder.operationId("queryMoments")
+                        .description("Lists moments.")
+                        .tag(tag)
+                        .response(responseBuilder()
+                            .implementation(ListResult.generateGenericClass(MomentVo.class))
+                        );
+                    MomentPublicQuery.buildParameters(builder);
+                }
+            )
+            .GET("moments/{name}", this::getMomentByName,
+                builder -> builder.operationId("queryMomentByName")
+                    .description("Gets a moment by name.")
+                    .tag(tag)
+                    .parameter(parameterBuilder()
+                        .in(ParameterIn.PATH)
+                        .name("name")
+                        .description("Moment name")
+                        .required(true)
+                    )
+                    .response(responseBuilder()
+                        .implementation(MomentVo.class)
+                    )
+            )
+            .build();
+    }
+
+
+    private Mono<ServerResponse> getMomentByName(ServerRequest request) {
+        final var name = request.pathVariable("name");
+        return momentFinder.get(name)
+            .switchIfEmpty(Mono.error(() -> new NotFoundException("Moment not found")))
+            .flatMap(moment -> ServerResponse.ok().contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(moment)
+            );
+    }
+
+    private Mono<ServerResponse> listMoments(ServerRequest request) {
+        MomentPublicQuery query = new MomentPublicQuery(request.exchange());
+        return momentPublicQueryService.list(query.toListOptions(), query.toPageRequest())
+            .flatMap(result -> ServerResponse.ok().contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(result)
+            );
+    }
+
+    @Override
+    public GroupVersion groupVersion() {
+        return GroupVersion.parseAPIVersion("api.moment.halo.run/v1alpha1");
+    }
+}

--- a/src/main/java/run/halo/moments/ReactiveQueryMomentPredicateResolver.java
+++ b/src/main/java/run/halo/moments/ReactiveQueryMomentPredicateResolver.java
@@ -1,0 +1,17 @@
+package run.halo.moments;
+
+import reactor.core.publisher.Mono;
+import run.halo.app.extension.ListOptions;
+
+import java.util.function.Predicate;
+
+/**
+ * The reactive query moment predicate resolver.
+ *
+ */
+public interface ReactiveQueryMomentPredicateResolver {
+
+    Mono<Predicate<Moment>> getPredicate();
+
+    Mono<ListOptions> getListOptions();
+}

--- a/src/main/java/run/halo/moments/finders/MomentFinder.java
+++ b/src/main/java/run/halo/moments/finders/MomentFinder.java
@@ -3,8 +3,10 @@ package run.halo.moments.finders;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import run.halo.app.extension.ListResult;
+import run.halo.moments.finders.impl.MomentFinderImpl.MomentQuery;
 import run.halo.moments.vo.MomentTagVo;
 import run.halo.moments.vo.MomentVo;
+import java.util.Map;
 
 
 /**
@@ -30,6 +32,13 @@ public interface MomentFinder {
      * @return a mono of list result.
      */
     Mono<ListResult<MomentVo>> list(Integer page, Integer size);
+
+    /**
+     * Lists moments by query params.
+     *
+     * @param params query params see {@link MomentQuery}
+     */
+    Mono<ListResult<MomentVo>> list(Map<String, Object> params);
 
     /**
      * List moments by tag.

--- a/src/main/java/run/halo/moments/finders/MomentPublicQueryService.java
+++ b/src/main/java/run/halo/moments/finders/MomentPublicQueryService.java
@@ -1,9 +1,11 @@
 package run.halo.moments.finders;
 
+import jakarta.annotation.Nonnull;
 import reactor.core.publisher.Mono;
 import run.halo.app.extension.ListOptions;
 import run.halo.app.extension.ListResult;
 import run.halo.app.extension.PageRequest;
+import run.halo.moments.Moment;
 import run.halo.moments.vo.MomentVo;
 
 public interface MomentPublicQueryService {
@@ -16,4 +18,6 @@ public interface MomentPublicQueryService {
      * @return a list of listed moment vo
      */
     Mono<ListResult<MomentVo>> list(ListOptions listOptions, PageRequest page);
+
+    Mono<MomentVo> getMomentVo(@Nonnull Moment moment);
 }

--- a/src/main/java/run/halo/moments/finders/MomentPublicQueryService.java
+++ b/src/main/java/run/halo/moments/finders/MomentPublicQueryService.java
@@ -1,0 +1,19 @@
+package run.halo.moments.finders;
+
+import reactor.core.publisher.Mono;
+import run.halo.app.extension.ListOptions;
+import run.halo.app.extension.ListResult;
+import run.halo.app.extension.PageRequest;
+import run.halo.moments.vo.MomentVo;
+
+public interface MomentPublicQueryService {
+
+    /**
+     * Lists public moments by the given list options and page request.
+     *
+     * @param listOptions additional list options
+     * @param page page request must not be null
+     * @return a list of listed moment vo
+     */
+    Mono<ListResult<MomentVo>> list(ListOptions listOptions, PageRequest page);
+}

--- a/src/main/java/run/halo/moments/finders/impl/MomentPublicQueryServiceImpl.java
+++ b/src/main/java/run/halo/moments/finders/impl/MomentPublicQueryServiceImpl.java
@@ -57,7 +57,8 @@ public class MomentPublicQueryServiceImpl implements MomentPublicQueryService {
             );
     }
 
-    private Mono<MomentVo> getMomentVo(@Nonnull Moment moment) {
+    @Override
+    public Mono<MomentVo> getMomentVo(@Nonnull Moment moment) {
         MomentVo momentVo = MomentVo.from(moment);
         return Mono.just(momentVo)
             .flatMap(mv -> populateStats(momentVo)

--- a/src/main/java/run/halo/moments/finders/impl/MomentPublicQueryServiceImpl.java
+++ b/src/main/java/run/halo/moments/finders/impl/MomentPublicQueryServiceImpl.java
@@ -1,0 +1,87 @@
+package run.halo.moments.finders.impl;
+
+import jakarta.annotation.Nonnull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import run.halo.app.core.extension.Counter;
+import run.halo.app.core.extension.User;
+import run.halo.app.extension.ListOptions;
+import run.halo.app.extension.ListResult;
+import run.halo.app.extension.PageRequest;
+import run.halo.app.extension.ReactiveExtensionClient;
+import run.halo.moments.Moment;
+import run.halo.moments.ReactiveQueryMomentPredicateResolver;
+import run.halo.moments.Stats;
+import run.halo.moments.finders.MomentPublicQueryService;
+import run.halo.moments.util.MeterUtils;
+import run.halo.moments.vo.ContributorVo;
+import run.halo.moments.vo.MomentVo;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class MomentPublicQueryServiceImpl implements MomentPublicQueryService {
+
+    private final ReactiveExtensionClient client;
+
+    private final ReactiveQueryMomentPredicateResolver momentPredicateResolver;
+
+    @Override
+    public Mono<ListResult<MomentVo>> list(ListOptions queryOptions, PageRequest page) {
+        return momentPredicateResolver.getListOptions()
+            .map(option -> {
+                var fieldSelector = queryOptions.getFieldSelector();
+                if (fieldSelector != null) {
+                    option.setFieldSelector(option.getFieldSelector()
+                        .andQuery(fieldSelector.query()));
+                }
+                var labelSelector = queryOptions.getLabelSelector();
+                if (labelSelector != null) {
+                    option.setLabelSelector(labelSelector);
+                }
+                return option;
+            })
+            .flatMap(listOptions -> client.listBy(Moment.class, listOptions, page)
+                .flatMap(list -> Flux.fromStream(list.get())
+                    .concatMap(this::getMomentVo)
+                    .collectList()
+                    .map(momentVos -> new ListResult<>(list.getPage(), list.getSize(),
+                        list.getTotal(), momentVos)
+                    )
+                )
+                .defaultIfEmpty(
+                    new ListResult<>(page.getPageNumber(), page.getPageSize(), 0L, List.of())
+                )
+            );
+    }
+
+    private Mono<MomentVo> getMomentVo(@Nonnull Moment moment) {
+        MomentVo momentVo = MomentVo.from(moment);
+        return Mono.just(momentVo)
+            .flatMap(mv -> populateStats(momentVo)
+                .doOnNext(mv::setStats)
+                .thenReturn(mv)
+            )
+            .flatMap(mv -> {
+                String owner = mv.getSpec().getOwner();
+                return client.fetch(User.class, owner)
+                    .map(ContributorVo::from)
+                    .doOnNext(mv::setOwner)
+                    .thenReturn(mv);
+            })
+            .defaultIfEmpty(momentVo);
+    }
+
+    private Mono<Stats> populateStats(MomentVo momentVo) {
+        String name = momentVo.getMetadata().getName();
+        return client.fetch(Counter.class, MeterUtils.nameOf(Moment.class, name))
+            .map(counter -> Stats.builder()
+                .upvote(counter.getUpvote())
+                .totalComment(counter.getTotalComment())
+                .approvedComment(counter.getApprovedComment())
+                .build())
+            .defaultIfEmpty(Stats.empty());
+    }
+}

--- a/src/main/java/run/halo/moments/util/SortUtils.java
+++ b/src/main/java/run/halo/moments/util/SortUtils.java
@@ -1,0 +1,43 @@
+package run.halo.moments.util;
+
+import lombok.experimental.UtilityClass;
+import org.springframework.data.domain.Sort;
+import org.springframework.lang.NonNull;
+import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
+import java.util.List;
+
+@UtilityClass
+public class SortUtils {
+    static final String delimiter = ",";
+
+    /**
+     * <p>Resolve from direction params, e.g. "name,asc" or "name"</p>
+     *
+     * @param directionParams direction params
+     * @return sort object
+     */
+    public static Sort resolve(List<String> directionParams) {
+        if (CollectionUtils.isEmpty(directionParams)) {
+            return Sort.unsorted();
+        }
+        Sort.Order[] orders = new Sort.Order[directionParams.size()];
+        for (int i = 0; i < directionParams.size(); i++) {
+            String[] parts = directionParams.get(i).split(delimiter);
+            if (parts.length == 1) {
+                orders[i] = new Sort.Order(Sort.Direction.ASC, parts[0]);
+            } else {
+                orders[i] = new Sort.Order(toDirection(parts[1]), parts[0]);
+            }
+        }
+        return Sort.by(orders);
+    }
+
+    private static Sort.Direction toDirection(@NonNull String direction) {
+        Assert.notNull(direction, "Direction must not be null");
+        if (direction.contains(" ")) {
+            throw new IllegalArgumentException("Direction must not contain whitespace");
+        }
+        return Sort.Direction.fromString(direction);
+    }
+}

--- a/src/main/resources/extensions/roleTemplate.yaml
+++ b/src/main/resources/extensions/roleTemplate.yaml
@@ -83,3 +83,15 @@ rules:
   - apiGroups: ["uc.api.moment.halo.run"]
     resources: ["moments", "tags"]
     verbs: ["delete", "deletecollection"]
+---
+apiVersion: v1alpha1
+kind: "Role"
+metadata:
+  name: role-template-moments-anonymous
+  labels:
+    halo.run/role-template: "true"
+    halo.run/hidden: "true"
+rules:
+  - apiGroups: [ "api.moment.halo.run" ]
+    resources: [ "moments" ]
+    verbs: [ "get", "list" ]

--- a/src/main/resources/extensions/roleTemplate.yaml
+++ b/src/main/resources/extensions/roleTemplate.yaml
@@ -91,6 +91,7 @@ metadata:
   labels:
     halo.run/role-template: "true"
     halo.run/hidden: "true"
+    rbac.authorization.halo.run/aggregate-to-anonymous: "true"
 rules:
   - apiGroups: [ "api.moment.halo.run" ]
     resources: [ "moments" ]


### PR DESCRIPTION

Fixes #175 

```release-note
为 momentFinder 添加一个统一参数的 list 方法并支持传递排序参数
为 moment 添加公开的查询的api
```