### PR TITLE
fix: ensure Moment scheme indices are re-registered on plugin restart and correct Boolean index queries

### DIFF
--- a/src/main/java/run/halo/moments/DefaultQueryMomentPredicateResolver.java
+++ b/src/main/java/run/halo/moments/DefaultQueryMomentPredicateResolver.java
@@ -43,7 +43,7 @@ public class DefaultQueryMomentPredicateResolver implements ReactiveQueryMomentP
         var listOptions = new ListOptions();
         var fieldQuery = and(
             isNull("metadata.deletionTimestamp"),
-            equal("spec.approved", Boolean.TRUE.toString())
+            equal("spec.approved", Boolean.TRUE)
         );
         var visibleQuery = equal("spec.visible", Moment.MomentVisible.PUBLIC.name());
         return currentUserName()

--- a/src/main/java/run/halo/moments/MomentQuery.java
+++ b/src/main/java/run/halo/moments/MomentQuery.java
@@ -109,7 +109,7 @@ public class MomentQuery extends SortableRequest {
         }
 
         if (getApproved() != null) {
-            query = and(query, equal("spec.approved", Boolean.toString(getApproved())));
+            query = and(query, equal("spec.approved", getApproved()));
         }
 
         if (getStartDate() != null) {

--- a/src/main/java/run/halo/moments/MomentReconciler.java
+++ b/src/main/java/run/halo/moments/MomentReconciler.java
@@ -86,7 +86,7 @@ public class MomentReconciler implements Reconciler<Reconciler.Request> {
             .workerCount(5)
             .onAddMatcher(DefaultExtensionMatcher.builder(client, moment.groupVersionKind())
                 .fieldSelector(
-                    FieldSelector.of(equal(Moment.REQUIRE_SYNC_ON_STARTUP_INDEX_NAME, "true"))
+                    FieldSelector.of(equal(Moment.REQUIRE_SYNC_ON_STARTUP_INDEX_NAME, Boolean.TRUE))
                 )
                 .build()
             )

--- a/src/main/java/run/halo/moments/MomentsPlugin.java
+++ b/src/main/java/run/halo/moments/MomentsPlugin.java
@@ -26,6 +26,7 @@ public class MomentsPlugin extends BasePlugin {
 
     @Override
     public void start() {
+        schemeManager.unregister(Scheme.buildFromType(Moment.class));
         schemeManager.register(Moment.class, indexSpecs -> {
             indexSpecs.add(IndexSpecs.<Moment, String>multi("spec.tags", String.class)
                 .indexFunc(moment -> {


### PR DESCRIPTION
## Summary

This PR fixes the "No indices found for type: run.halo.moments.Moment" error that causes the Moments plugin to fail to start or stop working after running for a while.

### Problem

1. **Index lifecycle bug**: When Halo's `DefaultIndexEngine` is destroyed (e.g., during plugin reload or certain runtime events), it clears all indices from `DefaultIndicesManager`. However, `DefaultSchemeManager` retains the scheme in its internal list. On the next `MomentsPlugin.start()`, `schemeManager.register()` sees the scheme already exists and skips index re-registration. This leaves the Moment extension without indices, causing all queries to fail with "No indices found for type".

2. **Boolean/String type mismatch**: The `spec.approved` and `REQUIRE_SYNC_ON_STARTUP` indices are declared with `Boolean.class`, but several query locations passed string values (`"true"` or `Boolean.TRUE.toString()`). This type mismatch could cause query failures or incorrect results depending on the index engine implementation.

### Changes

- **MomentsPlugin.java**: Call `schemeManager.unregister()` before `register()` in `start()` to ensure indices are always re-created, even if the scheme was previously registered but its indices were lost.

- **DefaultQueryMomentPredicateResolver.java**: Pass `Boolean.TRUE` instead of `"true"` for the `spec.approved` query.

- **MomentReconciler.java**: Pass `Boolean.TRUE` instead of `"true"` for the `REQUIRE_SYNC_ON_STARTUP` query.

- **MomentQuery.java**: Pass the raw `Boolean` value instead of `Boolean.toString(...)` for the `spec.approved` query.

### Related Issues

- Fixes #179
- Fixes #180
- Related to halo-dev/halo#8265