### PR TITLE
fix: paginate through all moments when building search index

### DIFF
--- a/src/main/java/run/halo/moments/ModelConst.java
+++ b/src/main/java/run/halo/moments/ModelConst.java
@@ -9,6 +9,4 @@ package run.halo.moments;
 public enum ModelConst {
     ;
     public static final String TEMPLATE_ID = "_templateId";
-    public static final Integer DEFAULT_PAGE_SIZE = 10;
-    public static final Integer SEARCH_DEFAULT_PAGE_SIZE = 200;
 }

--- a/src/main/java/run/halo/moments/search/MomentHaloDocumentsProvider.java
+++ b/src/main/java/run/halo/moments/search/MomentHaloDocumentsProvider.java
@@ -1,11 +1,10 @@
 package run.halo.moments.search;
 
-import static run.halo.moments.ModelConst.SEARCH_DEFAULT_PAGE_SIZE;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import run.halo.app.extension.ListOptions;
 import run.halo.app.extension.ListResult;
 import run.halo.app.extension.PageRequest;
@@ -26,6 +25,8 @@ public class MomentHaloDocumentsProvider implements HaloDocumentsProvider {
 
     public static final String MOMENT_DOCUMENT_TYPE = "moment.moment.halo.run";
 
+    private static final int PAGE_SIZE = 200;
+
     private final ReactiveExtensionClient client;
 
     private final DocumentConverter converter;
@@ -39,8 +40,10 @@ public class MomentHaloDocumentsProvider implements HaloDocumentsProvider {
         var pageRequest = createPageRequest();
         // make sure the moments are approved and not deleted.
         return client.listBy(Moment.class, options, pageRequest)
-            .map(ListResult::getItems)
-            .flatMapMany(Flux::fromIterable)
+            .expand(result -> result.hasNext()
+                ? client.listBy(Moment.class, options, nextPage(result, pageRequest.getSort()))
+                : Mono.empty())
+            .flatMap(result -> Flux.fromIterable(result.getItems()))
             .flatMap(converter::convert);
     }
 
@@ -50,7 +53,11 @@ public class MomentHaloDocumentsProvider implements HaloDocumentsProvider {
     }
 
     private PageRequest createPageRequest() {
-        return PageRequestImpl.of(1, SEARCH_DEFAULT_PAGE_SIZE,
+        return PageRequestImpl.of(1, PAGE_SIZE,
             Sort.by("metadata.creationTimestamp", "metadata.name"));
+    }
+
+    private static PageRequest nextPage(ListResult<Moment> result, Sort sort) {
+        return PageRequestImpl.of(result.getPage() + 1, result.getSize(), sort);
     }
 }


### PR DESCRIPTION
## Summary

Fixes search indexing only covering the first 200 moments. Any moments beyond the first page were never added to the search index.

### Problem

`MomentHaloDocumentsProvider.fetchAll()` used `client.listBy()` with a single fixed page request (page=1, size=200). When users had more than 200 approved moments, the excess moments were silently excluded from search results.

### Changes

- Use `.expand()` to recursively fetch all pages until `hasNext()` is false.
- Each subsequent request uses `result.getPage() + 1` as the next page number.
- Remove unused `SEARCH_DEFAULT_PAGE_SIZE` and `DEFAULT_PAGE_SIZE` constants from `ModelConst`.

### Pattern Reference

This follows the same pagination pattern used by `ReactiveExtensionPaginatedOperator` in the docsme plugin and `SubscriptionMigration.deleteInitialBatch()` in this plugin.