### PR TITLE
fix: 修复瞬间作者用户不存在时 RSS 输出 NPE 的问题

### DIFF
--- a/src/main/java/run/halo/moments/finders/impl/MomentPublicQueryServiceImpl.java
+++ b/src/main/java/run/halo/moments/finders/impl/MomentPublicQueryServiceImpl.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import run.halo.app.core.extension.Counter;
-import run.halo.app.core.extension.User;
+import run.halo.app.core.user.service.UserService;
 import run.halo.app.extension.ListOptions;
 import run.halo.app.extension.ListResult;
 import run.halo.app.extension.PageRequest;
@@ -25,6 +25,8 @@ import java.util.List;
 public class MomentPublicQueryServiceImpl implements MomentPublicQueryService {
 
     private final ReactiveExtensionClient client;
+
+    private final UserService userService;
 
     private final ReactiveQueryMomentPredicateResolver momentPredicateResolver;
 
@@ -67,7 +69,7 @@ public class MomentPublicQueryServiceImpl implements MomentPublicQueryService {
             )
             .flatMap(mv -> {
                 String owner = mv.getSpec().getOwner();
-                return client.fetch(User.class, owner)
+                return userService.getUserOrGhost(owner)
                     .map(ContributorVo::from)
                     .doOnNext(mv::setOwner)
                     .thenReturn(mv);


### PR DESCRIPTION
## Summary

修复瞬间的 `spec.owner` 指向不存在的用户（如作者已被删除）时，`/feed/moments/rss.xml` 整体 500 的问题。

### Problem

`MomentPublicQueryServiceImpl#getMomentVo` 中 `client.fetch(User.class, owner)` 查不到用户时，`MomentVo.owner` 保持 null，`MomentRssProvider#buildMomentTitle` 直接调用 `getOwner().getDisplayName()` 抛出 NPE：

```
java.lang.NullPointerException: Cannot invoke
"run.halo.moments.vo.ContributorVo.getDisplayName()"
because the return value of "run.halo.moments.vo.MomentVo.getOwner()" is null
    at run.halo.moments.rss.MomentRssProvider.buildMomentTitle(MomentRssProvider.java:168)
```

由于 RSS 由 `momentFinder.listAll()` 全量组装，单条数据即打挂整个订阅；主题模板访问 `moment.owner.*` 也会渲染报错。

### Changes

参考 Halo 核心对文章/评论作者的处理惯例，将 owner 解析改为 `UserService#getUserOrGhost`：用户不存在时回退到内置 ghost 用户（显示为「已删除用户」），保证 `MomentVo.owner` 始终非 null。该 API 位于 Halo api 模块，2.22 即已存在，兼容 `requires: ">=2.22.0"`。

### How to test

发布一条瞬间后删除其作者用户（或通过 API 创建 `spec.owner` 为不存在用户名的瞬间），访问 `/feed/moments/rss.xml`：修复前 500，修复后正常输出，该条目作者显示「已删除用户」。

Fixes #190

```release-note
修复瞬间作者用户不存在时 RSS 输出与主题渲染报错的问题，被删除用户的瞬间作者将显示为「已删除用户」
```