### PR TITLE
fix: 修复路由查询参数转换逻辑并移除重复refetch调用

### DIFF
--- a/console/src/uc/MomentsList.vue
+++ b/console/src/uc/MomentsList.vue
@@ -125,7 +125,6 @@ provide("tag", {
 watch([tag, momentsRangeTime], () => {
   page.value = 1;
   size.value = 20;
-  refetch();
 });
 
 usePluginShikiScriptLoader();

--- a/console/src/views/MomentsList.vue
+++ b/console/src/views/MomentsList.vue
@@ -28,7 +28,8 @@ const selectedApprovedStatus = useRouteQuery<string | undefined, boolean | undef
   undefined,
   {
     transform: (value) => {
-      return value ? value === "true" : undefined;
+      if (value === undefined || value === null) return undefined;
+      return typeof value === "string" ? value === "true" : value;
     },
   }
 );
@@ -115,7 +116,6 @@ provide("tag", {
 watch([tag, selectedApprovedStatus, momentsRangeTime], () => {
   page.value = 1;
   size.value = 20;
-  refetch();
 });
 
 const handleJumpToFrontDesk = () => {


### PR DESCRIPTION
1. 优化selectedApprovedStatus的参数转换逻辑，兼容null和非字符串类型值
2. 从两个组件的watch回调中移除重复的refetch调用
#192 